### PR TITLE
Switch guest import/export to Excel

### DIFF
--- a/package.json
+++ b/package.json
@@ -17,7 +17,8 @@
     "nuxt": "^4.0.2",
     "vue": "^3.5.17",
     "vue-router": "^4.5.1",
-    "zod": "^4.0.11"
+    "zod": "^4.0.11",
+    "xlsx": "^0.18.5"
   },
   "devDependencies": {
     "@primevue/nuxt-module": "^4.3.7",


### PR DESCRIPTION
## Summary
- replace CSV import/export UI with Excel version and add download-able template
- generate and download guests Excel file from frontend and API
- accept uploaded Excel workbooks and parse guest data on server

## Testing
- `npm test` *(fails: Missing script "test")*

------
https://chatgpt.com/codex/tasks/task_e_689549657dc8832e951a88dbe3b51412